### PR TITLE
103-FloodHistoryPR

### DIFF
--- a/frontend/BayouWatch_Frontend/package-lock.json
+++ b/frontend/BayouWatch_Frontend/package-lock.json
@@ -11,8 +11,10 @@
         "@types/react-router-dom": "^5.3.3",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
+        "node": "^25.2.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
         "react-leaflet-markercluster": "^5.0.0-rc.0",
         "react-router-dom": "^7.9.5"
@@ -2662,8 +2664,7 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
@@ -2790,6 +2791,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/node/-/node-25.2.1.tgz",
+      "integrity": "sha512-Rp87DFppNrZIUeKhzNeVHZ3/gHO0cT0ie89h4KONVRH/1vjz+tfMtUpUGyiHdph/1BfDpCDDdf4GcTLUGhgKxw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
+      "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA=="
     },
     "node_modules/node-releases": {
       "version": "2.0.21",
@@ -2992,11 +3013,18 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
       "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
-      "license": "Hippocratic-2.1",
       "dependencies": {
         "@react-leaflet/core": "^3.0.0"
       },

--- a/frontend/BayouWatch_Frontend/package.json
+++ b/frontend/BayouWatch_Frontend/package.json
@@ -13,8 +13,10 @@
     "@types/react-router-dom": "^5.3.3",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
+    "node": "^25.2.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
     "react-leaflet-markercluster": "^5.0.0-rc.0",
     "react-router-dom": "^7.9.5"

--- a/frontend/BayouWatch_Frontend/src/components/FloodReportCard.css
+++ b/frontend/BayouWatch_Frontend/src/components/FloodReportCard.css
@@ -4,7 +4,7 @@
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
   padding: 16px;
   margin-bottom: 16px;
-  width: 280px;
+  width: flex;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 

--- a/frontend/BayouWatch_Frontend/src/components/FloodReportCard.tsx
+++ b/frontend/BayouWatch_Frontend/src/components/FloodReportCard.tsx
@@ -8,12 +8,15 @@ import {
   FaExclamationTriangle,
 } from "react-icons/fa";
 
+// Defined severity types
+export type Severity = "severe" | "moderate" | "minor";
+
 interface FloodReportCardProps {
   reportedBy: string;
   date: string;
   location: string;
   type: string;
-  severity: string;
+  severity: Severity;
   description: string;
 }
 
@@ -25,8 +28,23 @@ const FloodReportCard: React.FC<FloodReportCardProps> = ({
   severity,
   description,
 }) => {
+
+  // Define colors for severity levels
+  const severityColors = {
+    severe: "#dc2626",   // red
+    moderate: "#f59e0b", // orange
+    minor: "#eab308",    // yellow
+  };
+
+  const sevColor = severityColors[severity];
+  
   return (
-    <div className="flood-card">
+    <div
+      className="flood-card"
+      style={{
+        borderLeft: `6px solid ${sevColor}`,
+      }}
+    >
       <div className="flood-card-row">
         <FaUser size={16} color="#007bff" />
         <span className="flood-label">Reported by:</span>

--- a/frontend/BayouWatch_Frontend/src/components/HistoryMap.tsx
+++ b/frontend/BayouWatch_Frontend/src/components/HistoryMap.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { MapContainer, TileLayer, useMap } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+import type { Severity } from "./MapMarker";
+import MapMarker from "./MapMarker";
+
+// Structure of reports pushed to HistoryMap
+// Used to center map marker when clicked
+export interface HistoryMapReport {
+  id: number;
+  latitude: number;
+  longitude: number;
+  description: string;
+  severity: Severity;
+}
+
+// Props for HistoryMap component
+interface HistoryMapProps {
+  selectedReport: HistoryMapReport | null;
+}
+
+const DEFAULT_CENTER: [number, number] = [30.45, -91.15]; // Baton Rouge
+
+// Moves map when report changes
+function MapUpdater({ center }: { center: [number, number] }) {
+  const map = useMap();
+
+  React.useEffect(() => {
+    map.flyTo(center, 14, { duration: 0.5 });
+  }, [center, map]);
+
+  return null;
+}
+
+// HistoryMap component displaying flood reports
+const HistoryMap: React.FC<HistoryMapProps> = ({ selectedReport }) => {
+  const center: [number, number] = selectedReport
+    ? [selectedReport.latitude, selectedReport.longitude]
+    : DEFAULT_CENTER;
+
+  return (
+    <MapContainer
+      center={center}
+      zoom={13}
+      style={{ width: "100%", height: "100%", borderRadius: 16 }}
+      scrollWheelZoom={true}
+    >
+      <TileLayer
+        attribution='&copy; OpenStreetMap contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+
+      {/* Fly-to animation */}
+      <MapUpdater center={center} />
+
+      {/* Severity marker colors*/}
+      {selectedReport && (
+        <MapMarker
+          latitude={selectedReport.latitude}
+          longitude={selectedReport.longitude}
+          severity={selectedReport.severity}
+          description={selectedReport.description}
+        />
+      )}
+    </MapContainer>
+  );
+};
+
+export default HistoryMap;

--- a/frontend/BayouWatch_Frontend/src/components/MapMarker.tsx
+++ b/frontend/BayouWatch_Frontend/src/components/MapMarker.tsx
@@ -3,7 +3,7 @@ import { Marker, Popup } from "react-leaflet";
 import { DivIcon } from "leaflet";
 
 
-type Severity = 'minor' | 'moderate' | 'severe';
+export type Severity = 'minor' | 'moderate' | 'severe';
 
 interface FloodMarkerProps {
     latitude: number;

--- a/frontend/BayouWatch_Frontend/src/pages/FloodHistory.css
+++ b/frontend/BayouWatch_Frontend/src/pages/FloodHistory.css
@@ -1,16 +1,87 @@
-.flood-history-page {
-  padding: 20px;
+
+.history-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px; /* theme.spacing.large */
 }
 
-.top-bar {
+.history-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 32px;
 }
 
-.reports-grid {
+.history-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.history-report-button {
+  background: #1d64ff;
+  color: white;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.history-report-button:hover {
+  background: #1550d4;
+}
+
+.history-subtitle {
+  margin-top: -10px;
+  margin-bottom: 20px;
+  font-size: 16px;
+  color: #666;
+}
+
+.history-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 16px;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+}
+
+/* Left column */
+.history-list {
+  background: #f9f9f9;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  height: 600px;
+  overflow-y: auto;
+}
+
+.history-clickable-card {
+  cursor: pointer;
+}
+
+.no-reports {
+  color: #777;
+}
+
+/* Right column */
+.history-map-panel {
+  background: #f9f9f9;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  height: 600px;
+}
+
+/* Placeholder styling for map area */
+.history-map-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 16px;
 }

--- a/frontend/BayouWatch_Frontend/src/pages/FloodHistory.tsx
+++ b/frontend/BayouWatch_Frontend/src/pages/FloodHistory.tsx
@@ -1,76 +1,143 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import FloodReportCard from "../components/FloodReportCard";
-import "./FloodHistory.css";
+import HistoryMap from "../components/HistoryMap";
+import type { HistoryMapReport } from "../components/HistoryMap";
+import "./FloodHistory.css"; // Page stylings
 
-// Mock data
-const mockReports = [
+// Defined severity types
+type Severity = "severe" | "moderate" | "minor";
+
+// Extended report type with additional fields
+interface FloodReport extends HistoryMapReport {
+  reportedBy: string;
+  date: string;
+  location: string;
+  type: string;
+}
+
+// Mock flood reports data, to be replaced through database integration
+const mockReports: FloodReport[] = [
   {
+    id: 1,
     reportedBy: "Alice",
-    date: "2025-11-10",
-    location: "Bayou St. John",
+    date: "2025-11-20",
+    location: "Choctaw Dr.",
     type: "Street Flood",
-    severity: "High",
-    description: "Flooded streets after heavy rain",
+    severity: "severe",
+    description: "Heavily flooded streets after heavy rain",
+    latitude: 30.470875,
+    longitude: -91.131796,
   },
   {
+    id: 2,
     reportedBy: "Bob",
-    date: "2025-11-11",
-    location: "French Quarter",
+    date: "2025-11-20",
+    location: "Perkins Rd.",
     type: "Localized Flood",
-    severity: "Medium",
-    description: "Minor street flooding in front of houses",
+    severity: "moderate",
+    description: "Moderate street flooding on busy roadway",
+    latitude: 30.420964,
+    longitude: -91.152794,
   },
   {
+    id: 3,
     reportedBy: "Charlie",
-    date: "2025-11-12",
-    location: "Lakeview",
+    date: "2025-11-24",
+    location: "Terrace Ave.",
     type: "Water Near Curb",
-    severity: "Low",
+    severity: "minor",
     description: "Water reaching the sidewalk but no road closure",
+    latitude: 30.436279,
+    longitude: -91.182348,
   },
   {
+    id: 4,
     reportedBy: "Dana",
-    date: "2025-11-13",
-    location: "Mid-City",
+    date: "2025-11-20",
+    location: "Nicholson Dr.",
     type: "Road Closure",
-    severity: "High",
+    severity: "severe",
     description: "Major roads closed due to flooding",
+    latitude: 30.404385,
+    longitude: -91.183482,
   },
   {
+    id: 5,
     reportedBy: "Eve",
-    date: "2025-11-14",
-    location: "Bywater",
+    date: "2025-11-23",
+    location: "E McKinley St.",
     type: "Localized Flood",
-    severity: "Medium",
-    description: "Localized flooding near parks and streets",
+    severity: "moderate",
+    description: "Localized flooding near streets and residences",
+    latitude: 30.423661,
+    longitude: -91.175389,
   },
 ];
 
+// Main Flood History page component
 export default function FloodHistory() {
   const navigate = useNavigate();
+  const [selectedReport, setSelectedReport] = React.useState<FloodReport | null>(
+    null
+  );
 
   return (
-    <div className="flood-history-page">
-      <div className="top-bar">
-        <h1>Flood History</h1>
-        <button onClick={() => navigate("/reporting")}>
-          Create Report
+    <div className="history-container">
+      {/* Title */}
+      <div className="history-header">
+        <h1 className="history-title">Flood History (Past 7 Days)</h1>
+
+        <button
+          className="history-report-button"
+          onClick={() => navigate("/reporting")}
+        >
+          Report New Flood
         </button>
       </div>
 
-      <div className="reports-grid">
-        {mockReports.map((report, idx) => (
-          <FloodReportCard
-            key={idx}
-            reportedBy={report.reportedBy}
-            date={report.date}
-            location={report.location}
-            type={report.type}
-            severity={report.severity}
-            description={report.description}
-          />
-        ))}
+      {/* Subtitle */}
+      <p className="history-subtitle">
+        See the latest flood activity around Baton Rouge. Click any report to
+        highlight it on the map.
+      </p>
+
+      {/* Content grid */}
+      <div className="history-grid">
+        {/* Left column */}
+        <div className="history-list">
+          {mockReports.length === 0 ? (
+            <p className="no-reports">No recent reports.</p>
+          ) : (
+            mockReports.map((r) => (
+              <div
+                key={r.id}
+                className="history-clickable-card"
+                onClick={() => setSelectedReport(r)}
+              >
+                <FloodReportCard
+                  reportedBy={r.reportedBy}
+                  date={r.date}
+                  location={r.location}
+                  type={r.type}
+                  severity={r.severity as Severity}
+                  description={r.description}
+                />
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Right column */}
+        <div className="history-map-panel">
+          {selectedReport ? (
+            <HistoryMap selectedReport={selectedReport} />
+          ) : (
+            <div className="history-map-placeholder">
+              🗺️ Click a report to view its location on the map
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
/////TASK/////
Display the past flood reports (last 7 days)

What to do:

Open src/pages/FloodHistory.tsx
Create hardcoded array of 5 mock reports with: id, latitude, longitude, severity, description, created_at, photo_url
Map through reports and display each in a card/list item
Color-code by severity: severe=red, moderate=orange, minor=yellow
Add "Report New Flood" button at top that links to /report
Show "No recent reports" message if array is empty

Done when:

Navigate to /history and see 5 report cards
Reports are color-coded by severity
"Report New Flood" button navigates to /report page
/////TASK/////

/////COMPLETED/////
Displays flood reports within 7 days, uses a scrollable panel so a history of 14-30 days should also display well
Each report is displayed as a card in one panel on the left, colored by severity, not filtered by date
Added a second panel on the left which displays the location of a flood report when clicked. Uses leaflet map and map markers from previous tasks. Default shows instructions on how to use map. It would be interesting to have pictures (if we add that feature) displayed here.
Included a "Report New Flood" button that routes to the Report page.
<img width="877" height="876" alt="image" src="https://github.com/user-attachments/assets/a321b384-399f-4dfe-9906-7fc78a134d53" />
<img width="876" height="879" alt="image" src="https://github.com/user-attachments/assets/1ae02f5e-a5b8-45ae-a456-806b2dbc102f" />
<img width="887" height="869" alt="image" src="https://github.com/user-attachments/assets/9c5219dc-66f3-4131-9068-e30ef59acb6f" />

